### PR TITLE
コーヒー豆の制約、エラー、フラッシュファイルのパーシャル化

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  add_flash_types :success, :info, :warning, :danger
 end

--- a/app/controllers/beens_controller.rb
+++ b/app/controllers/beens_controller.rb
@@ -18,21 +18,28 @@ class BeensController < ApplicationController
   end
 
   def update
-    been = been.find(params[:id])
-    been.update!(been_params)
-    redirect_to root_url, notice: "コーヒー豆「#{been.country_name}」を更新しました。"
+    @been = Been.find(params[:id])
+    if @been.update(been_params)
+      redirect_to root_url, success: "コーヒー豆「#{@been.country_name}」を更新しました。"
+    else
+      render :edit
+    end
   end
 
   def create
-    been = Been.new(been_params)
-    been.save!
-    redirect_to root_url, notice: "コーヒー豆#{been.country_name}を登録しました。"
+    @been = Been.new(been_params)
+
+    if @been.save
+      redirect_to root_url, success: "コーヒー豆「#{@been.country_name}」を登録しました。"
+    else
+      render :new
+    end
   end
 
   def destroy
     been = Been.find(params[:id])
     been.destroy
-    redirect_to root_url, notice: "コーヒー豆「#{been.country_name}」を削除しました。"
+    redirect_to root_url, success: "コーヒー豆「#{been.country_name}」を削除しました。"
   end
 
   private

--- a/app/models/been.rb
+++ b/app/models/been.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
 class Been < ApplicationRecord
+  validates :country_name, presence: true, length: { maximum: 30}
+  validates :farm_name, presence: true ,length: { maximum: 30 }
 end

--- a/app/views/beens/_form.html.slim
+++ b/app/views/beens/_form.html.slim
@@ -2,6 +2,7 @@
   .row
     .col-lg-8.offset-lg-2
       = form_with model: been, local: true do |f|
+        = render 'shared/error_messages', object: f.object
         .form-group.mr-20.ml-20
           = f.label :country_name
           = f.text_field :country_name, class: 'form-control', id: 'country_name'

--- a/app/views/beens/show.html.slim
+++ b/app/views/beens/show.html.slim
@@ -1,4 +1,4 @@
-h1 Beens#show
+h1 コーヒー豆詳細
 
 table.table.table-hover
   tbody

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -28,7 +28,5 @@ html
 	        li.nav-item
 	          a.nav-link href="#" ログアウト
     
-    .container
-      - if flash.notice.present?
-        .alert.alert-success.mt-10= flash.notice
+    = render 'shared/flash_message'
     = yield

--- a/app/views/shared/_error_messages.html.slim
+++ b/app/views/shared/_error_messages.html.slim
@@ -1,0 +1,5 @@
+- if object.errors.any?
+  #error-messages.alert.alert-danger
+    ul
+      - object.errors.full_messages.each do |message|
+        li = message

--- a/app/views/shared/_flash_message.html.slim
+++ b/app/views/shared/_flash_message.html.slim
@@ -1,0 +1,3 @@
+- flash.each do |message_type, message|
+  .alert.alert-success = message
+/ なぜが展開ができない？

--- a/db/migrate/20230104082917_change_beens_country_name_not_null.rb
+++ b/db/migrate/20230104082917_change_beens_country_name_not_null.rb
@@ -1,0 +1,5 @@
+class ChangeBeensCountryNameNotNull < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :beens, :country_name, false
+  end
+end

--- a/db/migrate/20230104084202_change_beens_column_limit30.rb
+++ b/db/migrate/20230104084202_change_beens_column_limit30.rb
@@ -1,0 +1,10 @@
+class ChangeBeensColumnLimit30 < ActiveRecord::Migration[5.2]
+  def up
+    change_column :beens, :country_name, :string, limit: 30
+    change_column :beens, :farm_name, :string, limit: 30
+  end
+  def down
+    change_column :beens, :country_name, :string
+    change_column :beens, :farm_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,15 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_221_220_051_629) do
-  # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+ActiveRecord::Schema.define(version: 2023_01_04_084202) do
 
-  create_table 'beens', force: :cascade do |t|
-    t.string 'country_name'
-    t.string 'farm_name'
-    t.text 'description'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "beens", force: :cascade do |t|
+    t.string "country_name", limit: 30, null: false
+    t.string "farm_name", limit: 30
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
+
 end


### PR DESCRIPTION
- Beensテーブルのcountry_nameとfarm_nameにnot_null制約を追記するマイグレーションファイルの作成
- 同じく両者にカラムに**limit**で最大３０文字までの制約を追記するマイグレーションファイルの作成
- Beenモデルにもcountry_nameとfarm_nameのバリデーション(presenceとmaximum)を追記
- エラーとフラッシュのパーシャルファイルを**app/views/shared**以下に作成
- **application_controller.rb**に**add_flash_type**ヘルパーで :success,:info,warning,dangerを使えるよう追記
- しかしなぜかフラッシュで展開ができないため、フラッシュメッセージのファイルのレイアウトは**alert-success**を一時的に代用