### PR TITLE
豆の詳細ページのレイアウトを変更、ログインしているユーザーと投稿したユーザーが一致している時のみ編集、削除ボタンを表示するように実装

### DIFF
--- a/app/controllers/beens_controller.rb
+++ b/app/controllers/beens_controller.rb
@@ -34,7 +34,7 @@ class BeensController < ApplicationController
 
   def destroy
     @been.destroy
-    redirect_to root_url, success: "コーヒー豆「#{been.country_name}」を削除しました。"
+    redirect_to root_url, success: "コーヒー豆「#{@been.country_name}」を削除しました。"
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,8 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true
 
   has_many :beens
+
+  def own?(object)
+    id == object.user_id
+  end
 end

--- a/app/views/beens/show.html.slim
+++ b/app/views/beens/show.html.slim
@@ -1,25 +1,13 @@
 h1 コーヒー豆詳細
 
-table.table.table-hover
-  tbody
-    tr
-      th= Been.human_attribute_name(:id)
-      td= @been.id
-    tr
-      th= Been.human_attribute_name(:country_name)
-      td= @been.country_name
-    tr
-      th= Been.human_attribute_name(:farm_name)
-      td= @been.farm_name
-    tr
-      th= Been.human_attribute_name(:description)
-      td= simple_format(h(@been.description), {}, sanitize: false, wrapper_tag: "div")
-    tr
-      th= Been.human_attribute_name(:created_at)
-      td= @been.created_at
-    tr
-      th= Been.human_attribute_name(:updated_at)
-      td= @been.updated_at
-
-= link_to '編集', edit_been_path, class: 'btn btn-primary mr-3'
-= link_to '削除', been_path(@been), method: :delete, data: { confirm: "コーヒー豆「#{@been.country_name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'
+.card.mb-3
+  = image_tag @been.been_image.url, class: 'card-img-top', height: 450
+  .card-body
+    h4.card-title = @been.country_name
+    h5.card-title = @been.farm_name
+    p.card-text = @been.description
+    p.card-text.small = @been.created_at
+    p.card-text.small = @been.updated_at
+    - if current_user.own?(@been)
+      = link_to '編集', edit_been_path, class: 'btn btn-primary mr-3'
+      = link_to '削除', been_path(@been), method: :delete, data: { confirm: "コーヒー豆「#{@been.country_name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'


### PR DESCRIPTION
- beens/showビューのレイアウトを変更
- models/user.rbにログインしているユーザーのidと豆を投稿したユーザーのidが一致しているか確認する**own?** メソッドを作成
- 上記のメソッドで一致している時のみ編集、削除ボタンを表示するように実装
- beensコントローラのdestroyアクションにあるフラッシュメッセージ内の変数beenをインスタンス変数@beenに修正